### PR TITLE
enh: sync README between `pt-br` and `eng` repos

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -1,32 +1,22 @@
 = Pro Git, Segunda Edição, Português do Brasil
 
-Bem-vindo à segunda edição do livro Pro Git
+Bem-vindo à segunda edição do livro Pro Git.
 
 > If you're looking for official version, in English, see https://github.com/progit/progit2[].
 
 Você pode achar esse livro online em: http://git-scm.com/book
 
-Como a primeira, a segunda edição do livro Pro Git é open source sob uma licença Creative Commons.
+Como na primeira edição, a segunda edição do livro Pro Git é open source sob uma licença Creative Commons.
 
-Algumas coisas mudaram desde quando a primeira edição foi disponibilizada de forma livre.
-Umas delas foi que mudamos o texto do livro de Markdown para o maravilhoso formato Asciidoc. Nós também passamos a usar a https://atlas.oreilly.com[Plataforma Atlas] da O'Reilly para a geração contínua dos livros, assim os formatos mais conhecidos estão sempre disponíves em todas os idiomas.
+Algumas coisas mudaram desde a liberação do código da primeira edição.
+Umas delas, nós passamos o texto do livro de Markdown para o maravilhoso formato Asciidoc.
 
-Nós também passamos a manter as traduções em repositórios separados em vez usar de subdiretórios do repositório original em inglês.
-Veja link:CONTRIBUTING.md[o documento para contribuições] para mais informações.
+Nós também passamos a manter as traduções em repositórios separados ao invés de usar subdiretórios do repositório em inglês.
+Veja link:TRANSLATING.md[o documento de tradução] para mais informações.
 
 == Como gerar o livro
 
-Existem algumas formas para gerar o e-book a partir deste código fonte.
-
-O mais fácil é simplesmente deixar que a gente faça isso.
-Um robô fica esperando por mudanças no branch principal e automaticamente gera o livro para todos.
-
-Você acha as versões atuais em http://git-scm.com/book[] e mais informações sobre a geração dos livros estão disponíveis em https://progit.org[].
-
-=== Manualmente
-
-Outra forma de gerar os arquivos do ebooks é de forma manual, usando o Asciidoctor.
-Se você executar os comandos a seguir você _deve_ obter os arquivos em HTML, Epub, Mobi e PDF:
+Você pode gerar os arquivos de e-book manualmente com o Asciidoctor. Se você executar o seguinte, você _pode_ atualmente obter arquivos de saída em HTML, Epub, Mobi e PDF:
 
 ----
 $ bundle install
@@ -38,54 +28,18 @@ Converting to EPub...
 Converting to Mobi (kf8)...
  -- Mobi output at progit.mobi
 Converting to PDF...
- -- PDF  output at progit.pdf
+ -- PDF output at progit.pdf
 ----
 
 Usamos os projetos `asciidoctor`, `asciidoctor-pdf` e `asciidoctor-epub`.
 
-=== No MacOS
+== Sinalizando uma issue
 
-Sugerido que utilize o http://brew.sh/[] para gerenciar as dependências de sistema (no caso, instalar o `ruby` e o `rubygems` mais recentes, para então instalar o `asciidoctor`).
+Antes de abrir uma issue, por favor verifique se já não existe alguma parecida no sistema de rastreio de bugs.
 
----
-# install updated version of ruby
-$ ruby -v
-$ brew install ruby
-$ source ~/.bashrc # or source ~/.zshrc
-$ ruby -v
-
-# update system rubygems
-$ gem update --system
-
-# config nokogiri to build using system libraries
-$ bundle config build.nokogiri --use-system-libraries
----
-
-Depois disso tudo, é só gerar os livros
-
----
-$ bundle exec rake book:build
----
-
-=== Via Docker
-
-Você não precisa instalar todas as dependências do Asciidoctor em seu sistema: usando Docker, com apenas um comando o livro é gerado por meio de um container efêmero. Esse só vai existir durante a geração do livro e depois some do sistema. O comando é esse aqui:
-
-----
-$ docker run -it --rm \
-    -v `pwd`:/documents/ \
-    rogeriopradoj/progit2
-----
-
-Copie todas as linhas e cole de uma vez no seu terminal. Pronto!
-
-== Indicação de problemas
-
-Antes de abrir uma issue indicando um problema, por favor verifique se já não existe alguma parecida aberta no sistema de rastreio de bugs.
-
-Além disso, se esse problema foi apontado no site git-scm.com, verifique também se ele não está presente aqui neste reposítorio.
-O problema pode ser sido resolvido, mas as mudanças ainda não terem sido implantadas e publicadas (deploy).
+Além disso, se essa issue foi apontada no site git-scm.com, por favor verifique também se ela ainda está presente aqui neste repositório.
+A issue já pode ter sido resolvida, mas as mudanças ainda não foram implantadas (deploy).
 
 == Contribuição
 
-Se você gostaria de nos ajudar fazendo alguma mudança ou com traduções, dê uma olhada no link:CONTRIBUTING.md[guia do contribuidor].
+Se você gostaria de ajudar fazendo alguma mudança, dê uma olhada no link:CONTRIBUTING.md[guia do contribuidor].


### PR DESCRIPTION
What
====

- Mirroring translations between pt-br and eng repos on `README.asciidoc`.

Why
===

- Pt-br repo have more lines, more text than eng repo.
- Needs to be the same number of sentences.
- Review some translations.

Where
=====

On `./README.asc`.

How
===

Steps to translate the pt-br README:

1. Use dicts, like Google translator and the command line trans.
2. Open all READMEs in paralel:
    - [English readme](https://github.com/progit/progit2/blob/master/README.asc);
    - [Old Pt-br readme](https://github.com/progit/progit2-pt-br/blob/master/README.asc);
    - My Pt-br readme, to be edited;
3. Use the online editor [asciidoclive](https://asciidoclive.com).

Results
=======

Changed `./README.asc` in many sentences.

Future work
===========

- What is a good tool to edit asciidoc (with viewer)?
- Change all markdown files to ascdoc files.
- How to know what sentences need to be translated?
- How to sync between foreign and english repositories?

---