### PR TITLE
Translating what was missing in ch02-git-basics.asc

### DIFF
--- a/ch02-git-basics.asc
+++ b/ch02-git-basics.asc
@@ -1,11 +1,11 @@
 [#ch02-git-basics]
 [[r_git_basics_chapter]]
-== Git Basics
+== Fundamentos de Git
 
 Se você pode ler apenas um capítulo antes de começar a usar o Git, este é ele.
 Este capítulo cobre cada comando básico que você precisa para fazer a maior parte das coisas com as quais eventualmente você vai se deparar durante seu uso do Git.
-No final deste capítulo, você será capaz de configurar e inicializar um repositório, iniciar e interromper o rastreamento de arquivos, usar a área de *stage* e realizar *commits* das alterações.
-Também mostraremos como configurar o Git para ignorar certos arquivos e padrões de arquivo, como desfazer erros de maneira rápida e fácil, como navegar no histórico do seu projeto e visualizar alterações entre *commits* e como fazer *push* e *pull* em repositórios remotos.
+No final deste capítulo, você será capaz de configurar e inicializar um repositório, iniciar e interromper o rastreamento de arquivos, usar a área de _stage_ e realizar _commits_ das alterações.
+Também mostraremos como configurar o Git para ignorar certos arquivos e padrões de arquivo, como desfazer erros de maneira rápida e fácil, como navegar no histórico do seu projeto e visualizar alterações entre _commits_ e como fazer _push_ e _pull_ em repositórios remotos.
 
 include::book/02-git-basics/sections/getting-a-repository.asc[]
 
@@ -21,7 +21,7 @@ include::book/02-git-basics/sections/tagging.asc[]
 
 include::book/02-git-basics/sections/aliases.asc[]
 
-=== Summary
+=== Sumário
 
-Nesse ponto, você já pode executar todas as operações locais básicas do Git - como criar ou clonar um repositório, fazer alterações, usar *stage* e *commit* para essas alterações e visualizar o histórico de todas as alterações pelas quais o repositório passou.
-A seguir, abordaremos o recurso matador do Git: seu modelo de ramificação (*branch*).
+Nesse ponto, você já pode executar todas as operações locais básicas do Git - como criar ou clonar um repositório, fazer alterações, usar _stage_ e _commit_ para essas alterações e visualizar o histórico de todas as alterações pelas quais o repositório passou.
+A seguir, abordaremos o recurso matador do Git: seu modelo de ramificação (_branch_).


### PR DESCRIPTION
- Subtitle translation
- Change from *bold* to _italic_ command names that do not need
translation.