### PR TITLE
Corrigindo palavra fora de contexto

### DIFF
--- a/book/02-git-basics/sections/getting-a-repository.asc
+++ b/book/02-git-basics/sections/getting-a-repository.asc
@@ -2,7 +2,7 @@
 === Obtendo um Repositório Git
 
 Você pode obter um projeto Git utilizando duas formas principais.
-A primeira faz uso de um projeto ou diretório existente e o importa para o Git.
+A primeira faz uso de um projeto ou diretório existente e o exporta para o Git.
 A segunda faz um clone de um repositório Git existente a partir de outro servidor.
 
 ==== Inicializando um Repositório em um Diretório Existente


### PR DESCRIPTION
No contexto a palavra apropriada seria a "exporta" que denota o sentido de mandar do local atual para fora, justamente o contrário da palavra atual (importa).
O clone do repositório git que seria uma importação.