### PR TITLE
Fictitious link should not be treated as a real link.

### DIFF
--- a/book-en/A-git-in-other-environments/sections/zsh.asc
+++ b/book-en/A-git-in-other-environments/sections/zsh.asc
@@ -40,7 +40,7 @@ It looks a bit like this:
 .Customized `zsh` prompt
 image::images/zsh-prompt.png[Customized `zsh` prompt]
 
-For more information on `vcs_info`, check out its documentation in the `zshcontrib(1)` manual page, or online at http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Version-Control-Information[].
+For more information on `vcs_info`, check out its documentation in the `zshcontrib(1)` manual page, or online at `http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Version-Control-Information`.
 
 Instead of `vcs_info`, you might prefer the prompt customization script that ships with Git, called `git-prompt.sh`; see https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh[] for details.
 `git-prompt.sh` is compatible with both Bash and Zsh.

--- a/book/04-git-server/sections/gitlab.asc
+++ b/book/04-git-server/sections/gitlab.asc
@@ -38,7 +38,7 @@ image::images/gitlab-menu.png[O item Área de administração no menu GitLab.]
 Usuários no GitLab são contas que correspondem a pessoas.
 As contas de usuário não têm muita complexidade; A conta de usuário é uma coleção de informações pessoais anexadas aos dados de login.
 Cada conta de usuário vem com um *namespace*, que é um agrupamento lógico de projetos que pertencem a esse usuário.
-Se o usuário +jane+ tivesse um projeto chamado +project+, o URL do projeto seria `http://servidor/jane/project`[].
+Se o usuário +jane+ tivesse um projeto chamado +project+, o URL do projeto seria `http://servidor/jane/project`.
 
 [[rgitlab_users]]
 .Tela de administração de usuários do GitLab.
@@ -55,7 +55,7 @@ Isso é obviamente uma ação muito mais permanete e destrutiva, e o uso disso �
 ===== Grupos
 
 Um grupo GitLab é um conjunto de projetos, juntamente com dados sobre como os usuários podem acessar esses projetos.
-Cada grupo tem um espaço para nome de projeto (da mesma forma que os usuários), então se o grupo +training+ tiver um projeto +materials+, sua url seria `http://servidor/training/materials`[].
+Cada grupo tem um espaço para nome de projeto (da mesma forma que os usuários), então se o grupo +training+ tiver um projeto +materials+, sua url seria `http://servidor/training/materials`.
 
 [[rgitlab_groups]]
 .Tela de administração de grupos do GitLab.

--- a/book/08-customizing-git/sections/attributes.asc
+++ b/book/08-customizing-git/sections/attributes.asc
@@ -63,7 +63,7 @@ What is the ``word'' filter?
 You have to set it up.
 Here you'll configure Git to use the `docx2txt` program to convert Word documents into readable text files, which it will then diff properly.
 
-First, you'll need to install `docx2txt`; you can download it from http://docx2txt.sourceforge.net[].
+First, you'll need to install `docx2txt`; you can download it from `http://docx2txt.sourceforge.net`.
 Follow the instructions in the `INSTALL` file to put it somewhere your shell can find it.
 Next, you'll write a wrapper script to convert output to the format Git expects.
 Create a file that's somewhere in your path called `docx2txt`, and add these contents:

--- a/book/A-git-in-other-environments/sections/zsh.asc
+++ b/book/A-git-in-other-environments/sections/zsh.asc
@@ -42,7 +42,7 @@ image::images/zsh-prompt.png[Customized `zsh` prompt.]
 
 For more information on vcs_info, check out its documentation
         in the `zshcontrib(1)` manual page,
-        or online at http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Version-Control-Information[].
+        or online at `http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Version-Control-Information`.
 
 Instead of vcs_info, you might prefer the prompt customization script that ships with Git, called `git-prompt.sh`; see https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh[] for details.
 `git-prompt.sh` is compatible with both Bash and Zsh.


### PR DESCRIPTION
Checking if the travis is going to result in an error. If so, it should not point out any more problems in the links below. Following @jnavila 's suggestion

- http://servidor/***
- http://docx2txt.sourceforge.net
- http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Version-Control-Information

Trying to understand the cause of the problem in PR: https://github.com/progit/progit2-pt-br/pull/51#issuecomment-846488324