### PR TITLE
Correção ortográfica da palavra "décimo" no Prefácio em português brasileiro.

### DIFF
--- a/book/preface.asc
+++ b/book/preface.asc
@@ -24,7 +24,7 @@ Um dos principais objetivos dessa nova edição é abordar todas essas novas fro
 A comunidade Open Source usando Git também explodiu.
 Quando eu originalmente sentei para escrever o livro cerca de cinco anos atrás (tomou-me um tempo para publicar a primeira versão), eu tinha acabado de conseguir emprego numa companhia pouco conhecida desenvolvendo um website de hospedagem de Git, chamado GitHub.
 No momento da publicação haviam talvez algumas milhares de pessoas usando o site e somente quatro de nós trabalhando nele.
-Enquanto escrevo essa introdução, GitHub está anunciando nosso décimio milionésimo projeto hospedado, com aproximadamente 5 milhões de contas de desenvolvedores cadastradas e mais de 230 funcionários.
+Enquanto escrevo essa introdução, GitHub está anunciando nosso décimo milionésimo projeto hospedado, com aproximadamente 5 milhões de contas de desenvolvedores cadastradas e mais de 230 funcionários.
 Ame-o ou Odeie-o, GitHub mudou drasticamente grandes esferas da comunidade Open Source de uma forma que era praticamente inconcebível quando sentei prara escrever a primeira edição.
 
 Escrevi uma pequena seção na versão original de Pro Git sobre o GitHub como um exemplo de hospedagem Git que nunca me senti confortável com ela.


### PR DESCRIPTION
Correção da palavra "décimo", que estava com a grafia "décimio".