### PR TITLE
Remoção de Termo em Inglês deixado para trás

### DIFF
--- a/book/03-git-branching/sections/basic-branching-and-merging.asc
+++ b/book/03-git-branching/sections/basic-branching-and-merging.asc
@@ -220,7 +220,7 @@ Unmerged paths:
 no changes added to commit (use "git add" and/or "git commit -a")
 ----
 
-Anything that has merge conflicts and hasn't been resolved is listed as unmerged. Qualquer arquivo que tenha conflitos que não foram solucionados é listado como _unmerged_("não mesclado".)
+Qualquer arquivo que tenha conflitos que não foram solucionados é listado como _unmerged_("não mesclado").
 O Git adiciona símbolos padrão de resolução de conflitos nos arquivos que têm conflitos, para que você possa abrí-los manualmente e solucionar os conflitos.
 O seu arquivo contém uma seção que se parece com isso:
 


### PR DESCRIPTION
Remoção do termo "Anything that has merge conflicts and hasn’t been resolved is listed as unmerged" no início do parágrafo, deixado para trás durante a tradução anterior.