### PR TITLE
Update begninners-guide.asc

### DIFF
--- a/beginners-guide.asc
+++ b/beginners-guide.asc
@@ -46,7 +46,7 @@ Antes de começar a trabalhar é necessário que seu repositório local esteja a
 
 Adicionalmente, o repositório pt-br é constantemente sincronizado com o repositório do livro em inglês, que continua recebendo alterações até hoje. Também é importante que você tenha essas modificações, para que você não corra o risco de traduzir uma versão desatualizada do arquivo.
 
-Fazer a sincronia é um processo fácil. Primeiro, você precisa adicionar o repositório pt-br original como um repositório remotom, ou *remote* (você só precisa fazer isso uma vez.) Você pode dar ao *remote* o nome que quiser, mas é uma convenção chamá-lo de *upstream.* Para adicionar o *remote*, execute o comando a seguir: 
+Fazer a sincronia é um processo fácil. Primeiro, você precisa adicionar o repositório pt-br original como um repositório remoto, ou *remote* (você só precisa fazer isso uma vez.) Você pode dar ao *remote* o nome que quiser, mas é uma convenção chamá-lo de *upstream.* Para adicionar o *remote*, execute o comando a seguir: 
 
 `git remote add upstream https://github.com/progit/progit2-pt-br.git`
 


### PR DESCRIPTION
Na linha 49 está escrito "repositório remotom" onde o correto seria "repositório remoto"