### PR TITLE
Tradução da parte 4.3 (geração de chaves SSH) para português brasileiro

### DIFF
--- a/book/04-git-server/sections/generating-ssh-key.asc
+++ b/book/04-git-server/sections/generating-ssh-key.asc
@@ -40,7 +40,6 @@ Entretanto, se você utilizar uma senha, lembre-se de adicionar a opção `-o`; 
 Você também pode utilizar a ferramenta `ssh-agent` para não ter de entrar com sua toda vez.
 Agora, cada usuário que tenha feito os passos acima deve enviar sua chave pública a você ou a quem estiver administrando o servidor de Git (assumindo que um servidor SSH que requeira chaves públicas esteja sendo utilizado).
 Tudo que o administrador precisa fazer é copiar o conteúdo do arquivo `.pub` e enviá-lo por e-mail.
-All they have to do is copy the contents of the `.pub` file and email it.
 A chave tem mais ou menos esta aparência:
 
 [source,console]

--- a/book/04-git-server/sections/generating-ssh-key.asc
+++ b/book/04-git-server/sections/generating-ssh-key.asc
@@ -37,7 +37,7 @@ d0:82:24:8e:d7:f1:bb:9b:33:53:96:93:49:da:9b:e3 schacon@mylaptop.local
 
 Primeiro, o programa confirma onde você deseja salvar a chave (`.ssh/id_rsa`), e então pede duas vezes por uma frase secreta, a qual você pode deixar vazia se não deseja digitar uma senha quando utiliza as chaves.
 Entretanto, se você utilizar uma senha, lembre-se de adicionar a opção `-o`; ela salva a chave privada em um formato que é mais resistente a ataques de força bruta do que o formato padrão.
-Você também pode utilizar a ferramenta `ssh-agent` para não ter de entrar com sua toda vez.
+Você também pode utilizar a ferramenta `ssh-agent` para não ter de entrar com sua senha toda vez.
 Agora, cada usuário que tenha feito os passos acima deve enviar sua chave pública a você ou a quem estiver administrando o servidor de Git (assumindo que um servidor SSH que requeira chaves públicas esteja sendo utilizado).
 Tudo que o administrador precisa fazer é copiar o conteúdo do arquivo `.pub` e enviá-lo por e-mail.
 A chave tem mais ou menos esta aparência:

--- a/book/04-git-server/sections/generating-ssh-key.asc
+++ b/book/04-git-server/sections/generating-ssh-key.asc
@@ -1,13 +1,13 @@
 [[r_generate_ssh_key]]
-=== Generating Your SSH Public Key
+=== Gerando Sua Chave Pública SSH
 
-(((SSH keys)))
-That being said, many Git servers authenticate using SSH public keys.
-In order to provide a public key, each user in your system must generate one if they don't already have one.
-This process is similar across all operating systems.
-First, you should check to make sure you don't already have a key.
-By default, a user's SSH keys are stored in that user's `~/.ssh` directory.
-You can easily check to see if you have a key already by going to that directory and listing the contents:
+(((Chaves SSH)))
+Dito isto, muitos servidores de Git efetuam autenticação utilizando chaves públicas SSH.
+Para prover uma chave pública, cada usuário do seu sistema deve gerar uma chave se ainda não possui uma.
+Este processo é similar em todos os sistemas operacionais.
+Primeiro, você deve verificar e se certificar de que ainda não tem uma chave.
+Por padrão, as chaves de SSH de um determinado usuário são armazenadas no diretório `~/.ssh` daquele usuário.
+Você pode facilmente verificar se não já possui uma chave indo neste diretório e listando seu conteúdo:
 
 [source,console]
 ----
@@ -17,9 +17,9 @@ authorized_keys2  id_dsa       known_hosts
 config            id_dsa.pub
 ----
 
-You're looking for a pair of files named something like `id_dsa` or `id_rsa` and a matching file with a `.pub` extension.
-The `.pub` file is your public key, and the other file is your private key.
-If you don't have these files (or you don't even have a `.ssh` directory), you can create them by running a program called `ssh-keygen`, which is provided with the SSH package on Linux/Mac systems and comes with Git for Windows:
+O que você precisa encontrar é um par de arquivos, um com o nome parecido com `id_dsa` ou `id_rsa`, e o outro de nome correspondente, porém com a extensão `.pub` no final.
+O arquivo de extensão `.pub` é sua chave pública, e o outro arquivo é sua chave privada.
+Caso você não tenha estes arquivos (ou sequer um diretório `.ssh`), você pode criá-los rodando um programa chamado `ssh-keygen`, que vem incluído no pacote SSH em sistemas Linux/Mac, e também no Git para Windows:
 
 [source,console]
 ----
@@ -35,11 +35,13 @@ The key fingerprint is:
 d0:82:24:8e:d7:f1:bb:9b:33:53:96:93:49:da:9b:e3 schacon@mylaptop.local
 ----
 
-First it confirms where you want to save the key (`.ssh/id_rsa`), and then it asks twice for a passphrase, which you can leave empty if you don't want to type a password when you use the key.
-
-Now, each user that does this has to send their public key to you or whoever is administrating the Git server (assuming you're using an SSH server setup that requires public keys).
+Primeiro, o programa confirma onde você deseja salvar a chave (`.ssh/id_rsa`), e então pede duas vezes por uma frase secreta, a qual você pode deixar vazia se não deseja digitar uma senha quando utiliza as chaves.
+Entretanto, se você utilizar uma senha, lembre-se de adicionar a opção `-o`; ela salva a chave privada em um formato que é mais resistente a ataques de força bruta do que o formato padrão.
+Você também pode utilizar a ferramenta `ssh-agent` para não ter de entrar com sua toda vez.
+Agora, cada usuário que tenha feito os passos acima deve enviar sua chave pública a você ou a quem estiver administrando o servidor de Git (assumindo que um servidor SSH que requeira chaves públicas esteja sendo utilizado).
+Tudo que o administrador precisa fazer é copiar o conteúdo do arquivo `.pub` e enviá-lo por e-mail.
 All they have to do is copy the contents of the `.pub` file and email it.
-The public keys look something like this:
+A chave tem mais ou menos esta aparência:
 
 [source,console]
 ----
@@ -52,4 +54,4 @@ mZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx
 NrRFi9wrf+M7Q== schacon@mylaptop.local
 ----
 
-For a more in-depth tutorial on creating an SSH key on multiple operating systems, see the GitHub guide on SSH keys at https://help.github.com/articles/generating-ssh-keys[].
+Para ver um tutorial mais detalhado sobre a criação de chaves SSH em diversos sistemas operacionais, veja o guia do GitHub sobre chaves SSH em https://docs.github.com/pt/authentication/connecting-to-github-with-ssh[].


### PR DESCRIPTION
Se quiserem dar uma olhada... fiz isto há uns meses atrás, traduzi esta parte especificamente com o intuito de linkar para esta página ao documentar algo para orientar pessoas do TI não devs no meu emprego anterior. Eu tomei a liberdade de traduzir com base em uma versão mais recente da documentação em inglês. Me digam se tiverem alguma observação a respeito das escolhas de palavras pra eu mudar, por favor!