### PR TITLE
Corrigido bloco de código que apresenta conflito resultante de tentativa de merge assim como está no original

### DIFF
--- a/book/03-git-branching/sections/basic-branching-and-merging.asc
+++ b/book/03-git-branching/sections/basic-branching-and-merging.asc
@@ -226,9 +226,13 @@ O seu arquivo contém uma seção que se parece com isso:
 
 [source,html]
 ----
+<<<<<<< HEAD:index.html
+<div id="footer">contact : email.support@github.com</div>
+=======
 <div id="footer">
  please contact us at support@github.com
 </div>
+>>>>>>> iss53:index.html
 ----
 
 Isso significa que a versão em `HEAD` (o seu branch `master`, porque era o que estava selecionado quando você executou o comando merge) é a parte superior daquele bloco (tudo após `=======`), enquanto que a versão no branch `iss53` contém a versão na parte de baixo.


### PR DESCRIPTION
Observei que deveria haver um bloco de código com um exemplo de conflito de merge e havia apenas um trecho de código html, código este exatamente igual ao bloco de código seguinte.
Fui conferir a versão original em inglês e ela estava como me pareceu que deveria ser.
Espero ter colaborado.