### PR TITLE
remove broken links

### DIFF
--- a/book/09-git-and-other-scms/sections/client-bzr.asc
+++ b/book/09-git-and-other-scms/sections/client-bzr.asc
@@ -1,6 +1,6 @@
 ==== Git and Bazaar
 
-Among the DVCS, another famous one is http://bazaar.canonical.com/[Bazaar].
+Among the DVCS, another famous one is Bazaar.
 Bazaar is free and open source, and is part of the http://www.gnu.org/[GNU Project].
 It behaves very differently from Git.
 Sometimes, to do the same thing as with Git, you have to use a different keyword, and some keywords that are common don't have the same meaning.

--- a/book/A-git-in-other-environments/sections/visualstudio.asc
+++ b/book/A-git-in-other-environments/sections/visualstudio.asc
@@ -22,4 +22,4 @@ image::images/vs-2.png[The Home view for a Git repository in Visual Studio.]
 
 Visual Studio now has a powerful task-focused UI for Git.
 It includes a linear history view, a diff viewer, remote commands, and many other capabilities.
-For complete documentation of this feature (which doesn't fit here), go to http://msdn.microsoft.com/en-us/library/hh850437.aspx[].
+For complete documentation of this feature (which doesn't fit here), go to https://learn.microsoft.com/en-us/visualstudio/version-control/git-with-visual-studio?view=vs-2022[].


### PR DESCRIPTION
Neste commit, eu removo alguns links quebrados que estão atrapalhando o build do livro. Esta é uma medida paliativa, porém; o problema real parece ser de que o livro está bastante desatualizado com relação à versão original em inglês, ocasionando referências a conceitos e/ou ferramentas obsoletas.

A solução de longo prazo é atualizarmos o repositório em relação ao livro original.